### PR TITLE
Fix calendar 400 error: remove non-existent contestPhase from class-l…

### DIFF
--- a/src/app/dashboard/calendar/page.tsx
+++ b/src/app/dashboard/calendar/page.tsx
@@ -404,13 +404,10 @@ export default function CalendarPage() {
 
   // Get safe syllabus description
   const getSyllabusDescription = (lesson: ClassLesson) => {
-    return (
-      lesson?.description ||
-      (lesson?.syllabi &&
-        lesson.syllabi.length > 0 &&
-        lesson.syllabi[0]?.description) ||
-      "No hay descripción disponible."
-    );
+    if (lesson?.syllabi && lesson.syllabi.length > 0 && lesson.syllabi[0]?.description) {
+      return lesson.syllabi[0].description;
+    }
+    return "No hay descripción disponible.";
   };
 
   // Get safe teacher name

--- a/src/services/classLessonService.ts
+++ b/src/services/classLessonService.ts
@@ -54,7 +54,7 @@ export const mapBackendClassLessonToFrontendClassLesson = (
         color: "#808080",
       },
     })),
-    contestPhase: classLesson?.contestPhase?.title || "",
+    contestPhase: "",
     presentationURL: classLesson?.presentation?.url || "",
     classRecordingURL: classLesson?.classRecordingURL || "",
     meetingURL: classLesson?.meetingURL || "",
@@ -85,9 +85,6 @@ export const fetchUserClassLessons = async (): Promise<ClassLesson[]> => {
             fields: "*",
           },
           notesFromClass: {
-            fields: "*",
-          },
-          contestPhase: {
             fields: "*",
           },
         },
@@ -136,9 +133,6 @@ export const fetchUserClassLessonsByContestCycle = async (
             fields: "*",
           },
           notesFromClass: {
-            fields: "*",
-          },
-          contestPhase: {
             fields: "*",
           },
         },


### PR DESCRIPTION
…esson queries

The contestPhase field does not exist in the Strapi class-lesson content type, causing a 400 ValidationError. Also fix getSyllabusDescription to avoid rendering Strapi blocks objects directly as React children.